### PR TITLE
fix build error on Windows due to incorrect RTL linkage for `environ`: must be a `dllimport`.

### DIFF
--- a/src/cpp/subprocess/environ.cpp
+++ b/src/cpp/subprocess/environ.cpp
@@ -6,7 +6,11 @@
 #include "utf8_to_utf16.hpp"
 using std::to_string;
 
-extern "C" char **environ;
+#if !defined(_DCRTIMP)     // Windows-specific RTL DLL import macro
+#define _DCRTIMP
+#endif
+
+extern "C" _DCRTIMP char **environ;
 
 namespace subprocess {
     Environ cenv;


### PR DESCRIPTION
MSVC started yakking about *inconsistent DLL linkage for `environ`*. This fixes that, though in a wee bit hacky way. (It *does* use the MSVC-provided `#define` for this so this should work for all types of builds (static and dynamic linking of RTL libraries)