### PR TITLE
fix MSVC build error: members in initialization must occur in order of class declaration.

### DIFF
--- a/test/examples.cpp
+++ b/test/examples.cpp
@@ -35,9 +35,9 @@ void simple() {
 #if __cplusplus >= 202002L
     // capture output. You can do this syntax if you have C++20
     process = subprocess::run({"echo", "hello", "world"}, {
-        .cout = PipeOption::pipe,
-        // make true to throw exception
-        .check = false
+		// make true to throw exception
+		.check = false,
+		.cout = PipeOption::pipe
     });
 
     std::cout << "captured: " << process.cout << '\n';


### PR DESCRIPTION
MSVC2019 yakked about this and errored out during compilation because of this.