### PR TITLE
fix #5: fatal system error exception in CloseHandle (invalid handle) due to double close of `cin`

### DIFF
--- a/src/cpp/subprocess/ProcessBuilder.hpp
+++ b/src/cpp/subprocess/ProcessBuilder.hpp
@@ -151,7 +151,9 @@ namespace subprocess {
         /** Closes the cin pipe */
         void close_cin() {
             if (cin != kBadPipeValue) {
-                pipe_close(cin);
+				if (!cin_is_autoclosed) {
+					pipe_close(cin);
+				}
                 cin = kBadPipeValue;
             }
         }
@@ -162,6 +164,7 @@ namespace subprocess {
 #ifdef _WIN32
         PROCESS_INFORMATION process_info;
 #endif
+		bool cin_is_autoclosed = false;
     };
 
 


### PR DESCRIPTION
fix (https://github.com/benman64/subprocess/issues/5) fatal system error exception in CloseHandle (invalid handle) due to double close of `cin`: once through `cin` pipe thread's `autoclose=true` (as it *should* be), then, when the subprocess has terminated, the `cin` handle is *again* closed in the `POpen` destructor.

The fix is to 'remember' when `cin` is being processed with autoclose ON and then forego the second cleanup in the close/destructor code to prevent system exceptions and consequent application failure.

---

Since `cin` is a *public* POpen member, we chose this route, while initially considering passing `cin` as a mutable reference into the pipe thread, so it could be nilled on thread termination. This, however, would introduce potential race issues as the pipe thread would then modify the `cin` member variable out-of-band for thee main thread, which owns the POpen instance.

The current solution is safe for regular use, including the sample code where userland code writes to the `cin` pipe and then closes it explicitly using the provided `POpeen::close_cin()` API.