### PR TITLE
Fix WC_ERR_INVALID_CHARS macro conflicts

### DIFF
--- a/src/cpp/subprocess/utf8_to_utf16.cpp
+++ b/src/cpp/subprocess/utf8_to_utf16.cpp
@@ -144,7 +144,7 @@ namespace subprocess {
         return result;
     }
 
-#ifdef __MINGW32__
+#ifndef WC_ERR_INVALID_CHARS
     // mingw doesn't define this
     constexpr int WC_ERR_INVALID_CHARS = 0;
 #endif


### PR DESCRIPTION
The macro `WC_ERR_INVALID_CHARS` exists in mingw-w64:

https://github.com/mingw-w64/mingw-w64/blob/121331cffde0a4b6d738b017307d38feb8c513c9/mingw-w64-headers/include/winnls.h#L46
